### PR TITLE
Correct `npm cache clean` command in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ NPM shrinkwrap serializes your node_modules folder. Depending
 There are a few tricks to ensuring there is no unneeded churn
   in the output of `npm shrinkwrap`.
 
-This first is to ensure you install with `npm cache clear` so
+This first is to ensure you install with `npm cache clean` so
   that an `npm ls` output is going to consistently give you the
   `resolved` and `from` fields.
 


### PR DESCRIPTION
Change `npm cache clear` -> `npm cache clean` command in [Motivation / Reduce diff churn](https://github.com/uber/npm-shrinkwrap#reduce-diff-churn) section of the README. 

I'm assuming this is a typo as `npm cache clean` is listed as a command in the [npm-cache](https://www.npmjs.org/doc/cli/npm-cache.html) docs, but not `npm cache clear`.
