### PR TITLE
support --dev

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ function npmShrinkwrap(opts, callback) {
 
     getNPM().load({
         prefix: opts.dirname,
+        dev: opts.dev,
         loglevel: 'error'
     }, verifyTree);
 


### PR DESCRIPTION
We just need to configure npm in dev mode.

This allows `shrinkwrap({ dev: true })` and `npm-shrinkwrap --dev` to work.

cc @sh1mmer @micahr @cvrebert
