### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A consistent shrinkwrap tool
 
 ## Usage
 
-`$ npm-shinkwrap`
+`$ npm-shrinkwrap`
 
 This runs shrinkwrap, which verifies your package.json & 
   node_modules tree are in sync. If they are it runs shrinkwrap


### PR DESCRIPTION
Had to spend a minute figuring out why `npm install` didn't work until I realized I pasted the wrong name.
