### PR TITLE
Increase the buffer available to the 'exec' command

### DIFF
--- a/bin/diff.js
+++ b/bin/diff.js
@@ -88,7 +88,7 @@ function gitShow(sha, cwd, callback) {
 
     exec('git show ' + sha + ':npm-shrinkwrap.json', {
         cwd: cwd || process.cwd(),
-        maxBuffer: 500 * 1024
+        maxBuffer: 10000 * 1024
     }, ongit);
 }
 


### PR DESCRIPTION
Our `npm-shrinkwrap.json` file is current in the region of 250K which exceeds the maximum amount of data that the `exec` command can write to `stdout` by default, so we are seeing errors from this.

This increases the `maxBuffer` size to 500K (`exec` defaults to 200K).
