### PR TITLE
moved all errors into single file for easier analysis

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -1,0 +1,79 @@
+var TypedError = require('error/typed');
+
+var EmptyFile = TypedError({
+    message: 'npm-shrinkwrap must not be empty',
+    type: 'npm-shrinkwrap.missing'
+});
+
+var InvalidNPMVersion = TypedError({
+    type: 'npm-shrinkwrap.invalid_version',
+    message: 'Using an older version of npm-shrinkwrap.\n' +
+        'Expected version {existing} but found {current}.\n' +
+        'To fix: please run `npm install npm-shrinkwrap@{existing}`\n'
+});
+
+var NPMError = TypedError({
+    type: 'npm-shrinkwrap.npm-error',
+    message: 'Problems were encountered\n' +
+        'Please correct and try again.\n' +
+        '{problemsText}',
+    pkginfo: null,
+    problemsText: null
+});
+
+var InvalidVersionsNPMError = TypedError({
+    type: 'npm-shrinkwrap.npm-error.invalid-version',
+    message: 'Problems were encountered\n' +
+        'Please correct and try again\n' +
+        'invalid: {name}@{actual} {dirname}/node_modules/{name}',
+    errors: null,
+    name: null,
+    actual: null,
+    dirname: null
+});
+
+var NoTagError = TypedError({
+    type: 'missing.gitlink.tag',
+    message: 'Expected the git dependency {name} to have a ' +
+        'tag;\n instead I found {gitLink}'
+});
+
+var NonSemverTag = TypedError({
+    type: 'gitlink.tag.notsemver',
+    message: 'Expected the git dependency {name} to have a ' +
+        'valid version tag;\n instead I found {tag} for the ' +
+        'dependency {gitLink}'
+});
+
+var InvalidPackage = TypedError({
+    type: 'invalid.packagejson',
+    message: 'The package.json for module {name} in your ' +
+        'node_modules tree is malformed.\n Expected JSON with ' +
+        'a version field and instead got {json}'
+});
+
+var InvalidVersion = TypedError({
+    type: 'invalid.git.version',
+    message: 'The version of {name} installed is invalid.\n ' +
+        'Expected {expected} to be installed but instead ' +
+        '{actual} is installed.'
+});
+
+var MissingPackage = TypedError({
+    type: 'missing.package',
+    message: 'The version of {name} installed is missing.\n' +
+        'Expected {expected} to be installed but instead ' +
+            'found nothing installed.\n'
+});
+
+module.exports = {
+    EmptyFile: EmptyFile,
+    InvalidNPMVersion: InvalidNPMVersion,
+    NPMError: NPMError,
+    InvalidVersionsNPMError: InvalidVersionsNPMError,
+    NoTagError: NoTagError,
+    NonSemverTag: NonSemverTag,
+    InvalidPackage: InvalidPackage,
+    InvalidVersion: InvalidVersion,
+    MissingPackage: MissingPackage
+};

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "jshint": "2.5.6",
     "pre-commit": "0.0.9",
     "tap-spec": "~1.0.0",
-    "tape": "^3.0.0"
+    "tape": "^3.0.2"
   },
   "scripts": {
     "test": "npm run jshint -s && NODE_ENV=test node test/index.js | tap-spec",

--- a/set-resolved.js
+++ b/set-resolved.js
@@ -4,17 +4,11 @@ var template = require('string-template');
 var readJSON = require('read-json');
 var url = require('url');
 var semver = require('semver');
-var TypedError = require('error/typed');
 
+var errors = require('./errors.js');
 var version = require('./package.json').version;
 
 var NPM_URI = 'https://registry.npmjs.org/{name}/-/{name}-{version}.tgz';
-var INVALID_VERSION = TypedError({
-    type: 'npm-shrinkwrap.invalid_version',
-    message: 'Using an older version of npm-shrinkwrap.\n' +
-        'Expected version {existing} but found {current}.\n' +
-        'To fix: please run `npm install npm-shrinkwrap@{existing}`\n'
-});
 
 module.exports = setResolved;
 
@@ -51,7 +45,7 @@ function setResolved(opts, callback) {
         var existingVersion = json['npm-shrinkwrap-version'];
 
         if (existingVersion && semver.gt(existingVersion, version)) {
-            return callback(INVALID_VERSION({
+            return callback(errors.InvalidNPMVersion({
                 existing: existingVersion,
                 current: version
             }));

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,2 @@
 require('./npm-shrinkwrap.js');
 require('./git-https-use-case.js');
-require('./sync.js');

--- a/trim-and-sort-shrinkwrap.js
+++ b/trim-and-sort-shrinkwrap.js
@@ -4,13 +4,9 @@ var url = require('url');
 var safeJsonParse = require('safe-json-parse');
 var parallel = require('run-parallel');
 var sortedObject = require('sorted-object');
-var TypedError = require('error/typed');
 var readJSON = require('read-json');
 
-var EmptyFile = TypedError({
-    message: 'npm-shrinkwrap must not be empty',
-    type: 'npm-shrinkwrap.missing'
-});
+var errors = require('./errors.js');
 
 module.exports = trimFrom;
 
@@ -85,7 +81,7 @@ function trimFrom(opts, callback) {
             }
 
             if (file === '') {
-                return callback(EmptyFile());
+                return callback(errors.EmptyFile());
             }
 
             safeJsonParse(file, function (err, json) {


### PR DESCRIPTION
I wanted to change the error semantics of one of the
    errors but it was hard to find them as they
    were spread out over files.

I put all the errors in a single file so that
    reasoning about the error semantics of this
    package is easier.

cc @kriskowal @sh1mmer
