### PR TITLE
Don't require the v prefix on tags

### DIFF
--- a/analyze-dependency.js
+++ b/analyze-dependency.js
@@ -128,12 +128,11 @@ function isGitUrl (url) {
 function parseVersion(tag) {
     var char = tag[0];
 
-    if (char !== 'v') {
-        return null;
+    if (char === 'v') {
+        tag = tag.substr(1);
     }
 
-    var rest = tag.substr(1);
-    var isValid = validSemver(rest);
+    var isValid = validSemver(tag);
 
-    return isValid ? rest : null;
+    return isValid ? tag : null;
 }


### PR DESCRIPTION
I have no idea why you would require the `v` prefix. As far as I can tell that isn't part of semver.org and you have to strip it before running it through `require('semver').valid`, so the `semver` package doesn't consider it required.
