### PR TITLE
add "node-version" entry to npm-shrinkwrap.json

### DIFF
--- a/set-resolved.js
+++ b/set-resolved.js
@@ -53,6 +53,8 @@ function setResolved(opts, callback) {
 
         json['npm-shrinkwrap-version'] = version;
 
+        json['node-version'] = process.version;
+
         json = fixResolved(json, null);
 
         // if top level shrinkwrap has a `from` or `resolved`

--- a/trim-and-sort-shrinkwrap.js
+++ b/trim-and-sort-shrinkwrap.js
@@ -55,6 +55,7 @@ function recursiveSorted(json) {
         'from',
         'resolved',
         'npm-shrinkwrap-version',
+        'node-version',
         'dependencies'
     ]);
 


### PR DESCRIPTION
When caching `node_modules` directories based on `npm-shrinkwrap.json`, it's necessary to take the version of Node.js itself into account, since a given copy of a compiled C module might not be binary compatible with 2 different versions of Node.js. Thus, in the general case, cache entries must be separated by Node.js version.

To facilitate this, I propose adding a `"node-version"` entry to `npm-shrinkwrap.json`, whose value will be Node.js's version as reported by [`process.version`](http://nodejs.org/api/process.html#process_process_version).
I can put this behind a command-line flag, if that's deemed necessary.