### PR TITLE
`1.3.7` is valid version

### DIFF
--- a/analyze-dependency.js
+++ b/analyze-dependency.js
@@ -129,7 +129,7 @@ function parseVersion(tag) {
     var char = tag[0];
 
     if (char !== 'v') {
-        return null;
+        return validSemver(tag);
     }
 
     var rest = tag.substr(1);


### PR DESCRIPTION
I have got this warning.
> WARN: Expected the git dependency WanaKana to have a valid version tag;
>  instead I found 1.3.7 for the dependency WaniKani/WanaKana#1.3.7

However, the `1.3.7` is valid version, isn't it?

----

semver ignores the leading `v`.

```
$ node -pe 'v=require("semver");v.valid("1.3.7")'
1.3.7
$ node -pe 'v=require("semver");v.valid("v1.3.7")'
1.3.7
$ node -pe 'v=require("semver");v.valid("a1.3.7")'
null
```

I think it can be written more simply.

```
function parseVersion(tag) {
    return validSemver(tag);
}
```

And also,

```
var parseVersion = require('semver').valid;
```
