### PR TITLE
default keep-nested to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,12 @@ npm-shrinkwrap NOTES:
  - `trimFrom()` also sorts and rewrites the package.json
     for consistency
 
+ - By default, the npm-shrinkwrap algorithm does not dedupe
+   nested dependencies. This means that the shrinkwrap is
+   closer to the installed dependencies by default. If this
+   is not desired `--keepNested=false` can be passed to the
+   shrinkwrap cli
+
 ## Installation
 
 `npm install npm-shrinkwrap`

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -30,7 +30,7 @@ function main(opts, callback) {
 
     opts.keepNested = 'keep-nested' in opts ?
         !!opts['keep-nested'] : 'keepNested' in opts ?
-        !!opts.keepNested : false;
+        !!opts.keepNested : true;
 
     opts.warnOnNotSemver = opts.warnOnNotSemver ?
         opts.warnOnNotSemver : true;


### PR DESCRIPTION
This should make shrinkwraps less painful by default due to dedupe bugs.