### PR TITLE
support scoped package and using global npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ ehthumbs.db
 Icon?
 Thumbs.db
 coverage
+test/proj
 
 # Text Editor Byproducts #
 ##########################

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -25,6 +25,11 @@ function main(opts, callback) {
         return printHelp(opts);
     }
 
+    // use global or local npm
+    opts.useGlobalNPM = 'use-global-npm' in opts?
+        !!opts['use-global-npm'] : 'useGlobalNPM' in opts ?
+        !!opts.useGlobalNPM : false;
+
     opts.dirname = opts.dirname ?
         path.resolve(opts.dirname) : process.cwd();
 

--- a/bin/usage.md
+++ b/bin/usage.md
@@ -14,6 +14,7 @@ Options:
                       to warnings
   --dev               If set, will shrinkwrap dev dependencies
   --silent            If set, will be silent.
+  --use-global-npm    If set, will use global npm instead of bundled version
 
 ## `{cmd} --help`
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var ValidationError = require('error/validation');
 var find = require('array-find');
 var path = require('path');
 var fs = require('fs');
+var child = require("child_process");
 var sortedObject = require('sorted-object');
 var readJSON = require('read-json');
 
@@ -69,7 +70,7 @@ function npmShrinkwrap(opts, callback) {
     var _warnings = null;
     var _oldShrinkwrap = null;
 
-    getNPM().load({
+    loadNPM(opts.useGlobalNPM, {
         prefix: opts.dirname,
         dev: opts.dev,
         loglevel: 'error'
@@ -296,12 +297,36 @@ module.exports = npmShrinkwrap;
     The only fix is to clear the entire node require cache and
       get a fresh duplicate copy of the entire npm library
 */
-function getNPM() {
+function loadNPM(useGlobalNPM, opts, cb) {
     Object.keys(require.cache).forEach(function (key) {
         delete require.cache[key];
     });
-    var NPM = require('npm');
-    return NPM;
+
+    if (!useGlobalNPM) {
+      require('npm').load(opts, cb);
+
+      return;
+    }
+    
+    child.exec("npm prefix -g", function (error, stdout, stderr) {
+      var _err = stderr || error;
+      if (_err) {
+          // fake error like npm error
+          throw ERRORS.NPMError({
+              pkginfo: _err,
+              problemsText: _err.stack || _err.toString()
+          });
+      }
+
+      // removing trailing new line
+      var prefix = stdout.replace(/\n+$/, "");
+      var npmPath = path.join(prefix, "lib/node_modules/npm");
+      if (fs.existsSync(npmPath)) {
+          require(npmPath).load(opts, cb);
+      } else {
+          throw new Error("global NPM not found in " + npmPath);
+      }
+    });
 }
 
 function NPMError(pkginfo) {

--- a/load-npm.js
+++ b/load-npm.js
@@ -1,0 +1,44 @@
+var path = require('path');
+var fs = require('fs');
+var child = require("child_process");
+
+var ERRORS = require('./errors.js');
+
+/*  you cannot call `npm.load()` twice with different prefixes.
+    
+    The only fix is to clear the entire node require cache and
+      get a fresh duplicate copy of the entire npm library
+*/
+function loadNPM(useGlobalNPM, opts, cb) {
+    Object.keys(require.cache).forEach(function (key) {
+        delete require.cache[key];
+    });
+
+    if (!useGlobalNPM) {
+      require('npm').load(opts, cb);
+
+      return;
+    }
+    
+    child.exec("npm prefix -g", function (error, stdout, stderr) {
+      var _err = stderr || error;
+      if (_err) {
+          // fake error like npm error
+          throw ERRORS.NPMError({
+              pkginfo: _err,
+              problemsText: _err.stack || _err.toString()
+          });
+      }
+
+      // removing trailing new line
+      var prefix = stdout.replace(/\n+$/, "");
+      var npmPath = path.join(prefix, "lib/node_modules/npm");
+      if (fs.existsSync(npmPath)) {
+          require(npmPath).load(opts, cb);
+      } else {
+          throw new Error("global NPM not found in " + npmPath);
+      }
+    });
+}
+
+module.exports = loadNPM;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "fixtures-fs": "^2.0.0",
     "istanbul": "~0.3.2",
     "jshint": "2.5.6",
+    "mkdirp": "^0.5.1",
     "pre-commit": "0.0.9",
     "tap-spec": "~1.0.0",
     "tape": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "fixtures-fs": "^2.0.0",
     "istanbul": "~0.3.2",
     "jshint": "2.5.6",
-    "mkdirp": "^0.5.1",
     "pre-commit": "0.0.9",
     "tap-spec": "~1.0.0",
     "tape": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -37,9 +37,7 @@
     "tape": "^3.0.2"
   },
   "scripts": {
-    "pretest": "rm -fr test/proj /tmp/proj",
     "test": "npm run jshint -s && NODE_ENV=test node test/index.js | tap-spec",
-    "pretest-global-npm": "rm -fr test/proj",
     "test-global-npm": "npm run jshint -s && NODE_ENV=test useGlobalNPM=0 node test/index.js | tap-spec",
     "unit-test": "NODE_ENV=test node test/npm-shrinkwrap.js | tap-spec",
     "jshint-pre-commit": "jshint --verbose $(git diff --cached --name-only | grep '\\.js$')",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "scripts": {
     "test": "npm run jshint -s && NODE_ENV=test node test/index.js | tap-spec",
-    "test-global-npm": "npm run jshint -s && NODE_ENV=test useGlobalNPM=0 node test/index.js | tap-spec",
+    "test-global-npm": "npm run jshint -s && NODE_ENV=test useGlobalNPM=1 node test/index.js | tap-spec",
     "unit-test": "NODE_ENV=test node test/npm-shrinkwrap.js | tap-spec",
     "jshint-pre-commit": "jshint --verbose $(git diff --cached --name-only | grep '\\.js$')",
     "jshint": "jshint --verbose .",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,10 @@
     "tape": "^3.0.2"
   },
   "scripts": {
+    "pretest": "rm -fr test/proj /tmp/proj",
     "test": "npm run jshint -s && NODE_ENV=test node test/index.js | tap-spec",
+    "pretest-global-npm": "rm -fr test/proj",
+    "test-global-npm": "npm run jshint -s && NODE_ENV=test useGlobalNPM=0 node test/index.js | tap-spec",
     "unit-test": "NODE_ENV=test node test/npm-shrinkwrap.js | tap-spec",
     "jshint-pre-commit": "jshint --verbose $(git diff --cached --name-only | grep '\\.js$')",
     "jshint": "jshint --verbose .",

--- a/sync/index.js
+++ b/sync/index.js
@@ -2,7 +2,7 @@ var path = require('path');
 // var fs = require('fs');
 // var readJSON = require('read-json');
 var parallel = require('run-parallel');
-var npm = require('npm');
+var loadNPM = require('../load-npm.js');
 // var rimraf = require('rimraf');
 
 var read = require('./read.js');
@@ -30,7 +30,7 @@ function syncShrinkwrap(opts, cb) {
         npmOpts.registry = opts.registry;
     }
 
-    npm.load(npmOpts, function (err, npm) {
+    loadNPM(opts.useGlobalNPM, npmOpts, function (err, npm) {
         if (err) {
             return cb(err);
         }

--- a/sync/purge-excess.js
+++ b/sync/purge-excess.js
@@ -39,39 +39,54 @@ function purgeExcess(dir, shrinkwrap, opts, cb) {
     deps.
 */
 function findExcess(dir, shrinkwrap, opts, cb) {
-    fs.readdir(dir, function (err, files) {
-        if (err) {
-            return cb(err);
+    var files = [];
+    try {
+      files = fs.readdirSync(dir);
+    } catch (e) {
+      // re-create fs.readdir(...) error
+      return cb(e);
+    }
+
+    var i = 0;
+    while (i < files.length) {
+        // remove node_modules/.bin from check
+        if (/\.bin$/.test(files[i])) {
+            files.splice(i, 1);
         }
-
-        files = files.map(function (file) {
-            return file.toLowerCase();
-        }).filter(function (file) {
-            // remove node_modules/.bin from check
-            return file !== '.bin';
-        });
-
-        if (opts.dev && shrinkwrap.devDependencies) {
-            var devDeps = shrinkwrap.devDependencies;
-            var devKeys = Object.keys(devDeps).map(function (s) {
-                return s.toLowerCase();
-            });
-
-            files = files.filter(function (file) {
-                // remove anything that is a dev dep
-                return devKeys.indexOf(file) === -1;
-            });
+        // remove scoped packages in node_modules
+        else if (files[i][0] === "@" && files[i].indexOf("/") === -1) {
+            var subGroup = fs.readdirSync(path.join(dir, files[i]));
+            /* jslint loopfunc: true */
+            [].splice.apply(files, [i, 1].concat(subGroup.map(function(g) {
+                return path.join(files[i], g);
+            })));
         }
-
-        var deps = shrinkwrap.dependencies || {};
-        var keys = Object.keys(deps).map(function (s) {
+        else {
+            files[i] = files[i].toLowerCase();
+            i++;
+        }
+    }
+  
+    if (opts.dev && shrinkwrap.devDependencies) {
+        var devDeps = shrinkwrap.devDependencies;
+        var devKeys = Object.keys(devDeps).map(function (s) {
             return s.toLowerCase();
         });
 
-        // return all files in node_modules that are not
-        // in npm-shrinkwrap.json
-        cb(null, files.filter(function (file) {
-            return keys.indexOf(file) === -1;
-        }));
+        files = files.filter(function (file) {
+            // remove anything that is a dev dep
+            return devKeys.indexOf(file) === -1;
+        });
+    }
+
+    var deps = shrinkwrap.dependencies || {};
+    var keys = Object.keys(deps).map(function (s) {
+        return s.toLowerCase();
     });
+
+    // return all files in node_modules that are not
+    // in npm-shrinkwrap.json
+    cb(null, files.filter(function (file) {
+        return keys.indexOf(file) === -1;
+    }));
 }

--- a/test/git-https-use-case.js
+++ b/test/git-https-use-case.js
@@ -14,6 +14,9 @@ test('npm-shrinkwrap --dev on git+https uri', fixtures(__dirname, {
         'package.json': JSON.stringify({
             name: 'foo',
             version: '0.1.0',
+            description: "",
+            respository: "",
+            private: true, // hack to hide no readme warning
             dependencies: {},
             devDependencies: {
                 'gulp-yuidoc': 'git://github.com/' +
@@ -35,6 +38,7 @@ test('npm-shrinkwrap --dev on git+https uri', fixtures(__dirname, {
         shrinkwrapCli({
             dirname: PROJ,
             dev: true,
+            useGlobalNPM: process.env.useGlobalNPM,
             _: []
         }, function (err) {
             assert.ifError(err);

--- a/test/index.js
+++ b/test/index.js
@@ -1,2 +1,6 @@
-require('./npm-shrinkwrap.js');
-require('./git-https-use-case.js');
+var rimraf = require('rimraf');
+// clean up folder created in previous incomplete test
+rimraf('./proj', function() {
+  require('./npm-shrinkwrap.js');
+  require('./git-https-use-case.js');
+});

--- a/test/npm-shrinkwrap.js
+++ b/test/npm-shrinkwrap.js
@@ -2,13 +2,6 @@ var test = require('tape');
 var fixtures = require('fixtures-fs');
 var path = require('path');
 var fs = require('fs');
-var mkdirp = require("mkdirp");
-
-// a hack to workaround fixtures-fs
-// override fs.mkdirp and leaving all other functions intact
-var _fs = Object.create(fs);
-_fs.mkdir = mkdirp;
-
 
 var npmShrinkwrap = require('../index.js');
 
@@ -113,12 +106,14 @@ test('creates simple shrinkwrap for scoped package', fixtures(__dirname, {
             "@th507/foo": '1.0.0'
         },
         'node_modules': {
-            '@th507/foo': moduleFixture('@th507/foo', '1.0.0')
+            '@th507' : {
+                'foo': moduleFixture('@th507/foo', '1.0.0')
+            }
         }
     })
 }, function (assert) {
     // old version of npm which is bundled w/ this package
-    // does not support scoped package and will failed
+    // does not support scoped package and will failed.
     // setting use-global-npm for this test case only
     var _OPT;
     if (typeof OPT === "string") {
@@ -154,9 +149,6 @@ test('creates simple shrinkwrap for scoped package', fixtures(__dirname, {
             assert.end();
         });
     });
-}, {
-  mkdirp: mkdirp,
-  fs: _fs
 }));
 
 

--- a/test/npm-shrinkwrap.js
+++ b/test/npm-shrinkwrap.js
@@ -8,6 +8,14 @@ var npmShrinkwrap = require('../index.js');
 var PROJ = path.join(__dirname, 'proj');
 var SHA = 'e8db5304e8e527aa17093cd9de66725118d9b589';
 
+var OPT = PROJ;
+if (process.env.useGlobalNPM) {
+  OPT = {
+    dirname: PROJ,
+    useGlobalNPM: process.env.useGlobalNPM
+  };
+}
+
 function moduleFixture(name, version, opts) {
     opts = opts || {};
 
@@ -68,7 +76,7 @@ test('creates simple shrinkwrap', fixtures(__dirname, {
         }
     })
 }, function (assert) {
-    npmShrinkwrap(PROJ, function (err) {
+    npmShrinkwrap(OPT, function (err) {
         assert.ifError(err);
 
         var shrinkwrap = path.join(PROJ, 'npm-shrinkwrap.json');
@@ -136,7 +144,7 @@ test('error on removed module', fixtures(__dirname, {
     })
 }, function (assert) {
     // debugger;
-    npmShrinkwrap(PROJ, function (err) {
+    npmShrinkwrap(OPT, function (err) {
         assert.ok(err);
 
         assert.notEqual(err.message.indexOf(
@@ -152,7 +160,7 @@ test('error on additional module', fixtures(__dirname, {
         'node_modules': {}
     })
 }, function (assert) {
-    npmShrinkwrap(PROJ, function (err) {
+    npmShrinkwrap(OPT, function (err) {
         assert.ok(err);
 
         assert.notEqual(err.message.indexOf(
@@ -170,7 +178,7 @@ test('error on invalid module', fixtures(__dirname, {
         }
     })
 }, function (assert) {
-    npmShrinkwrap(PROJ, function (err) {
+    npmShrinkwrap(OPT, function (err) {
         assert.ok(err);
 
         assert.notEqual(err.message.indexOf(
@@ -189,7 +197,7 @@ test('error on removed GIT module', fixtures(__dirname, {
     })
 }, function (assert) {
     // debugger;
-    npmShrinkwrap(PROJ, function (err) {
+    npmShrinkwrap(OPT, function (err) {
         assert.ok(err);
 
         assert.notEqual(err.message.indexOf(
@@ -204,14 +212,21 @@ test('error on additional GIT module', fixtures(__dirname, {
         dependencies: {
             'foo': 'git://github.com:uber/foo#v1.0.0'
         },
-        'node_modules': {}
+        'node_modules': {},
+        nonono: 1
     })
 }, function (assert) {
-    npmShrinkwrap(PROJ, function (err) {
+    npmShrinkwrap(OPT, function (err) {
         assert.ok(err);
 
         assert.notEqual(err.message.indexOf(
-            'missing: foo@git://github.com:uber/foo#v1.0.0'), -1);
+            'missing: foo@git://github.com'), -1);
+
+        assert.notEqual(err.message.indexOf(
+            'uber/foo'), -1);
+
+        assert.notEqual(err.message.indexOf(
+            '#v1.0.0'), -1);
 
         assert.end();
     });
@@ -227,7 +242,7 @@ test('error on invalid GIT module', fixtures(__dirname, {
         }
     })
 }, function (assert) {
-    npmShrinkwrap(PROJ, function (err) {
+    npmShrinkwrap(OPT, function (err) {
         assert.ok(err);
 
         assert.notEqual(err ? err.message.indexOf(

--- a/test/npm-shrinkwrap.js
+++ b/test/npm-shrinkwrap.js
@@ -2,6 +2,13 @@ var test = require('tape');
 var fixtures = require('fixtures-fs');
 var path = require('path');
 var fs = require('fs');
+var mkdirp = require("mkdirp");
+
+// a hack to workaround fixtures-fs
+// override fs.mkdirp and leaving all other functions intact
+var _fs = Object.create(fs);
+_fs.mkdir = mkdirp;
+
 
 var npmShrinkwrap = require('../index.js');
 
@@ -99,6 +106,59 @@ test('creates simple shrinkwrap', fixtures(__dirname, {
         });
     });
 }));
+
+test('creates simple shrinkwrap for scoped package', fixtures(__dirname, {
+    'proj': moduleFixture('proj', '0.1.0', {
+        dependencies: {
+            "@th507/foo": '1.0.0'
+        },
+        'node_modules': {
+            '@th507/foo': moduleFixture('@th507/foo', '1.0.0')
+        }
+    })
+}, function (assert) {
+    // old version of npm which is bundled w/ this package
+    // does not support scoped package and will failed
+    // setting use-global-npm for this test case only
+    var _OPT;
+    if (typeof OPT === "string") {
+        _OPT = {
+            dirname: OPT,
+            useGlobalNPM: 1
+        };
+    }
+    else {
+        _OPT = Object.create(OPT);
+        _OPT.useGlobalNPM = 1;
+    }
+
+    npmShrinkwrap(_OPT, function (err) {
+        assert.ifError(err);
+
+        var shrinkwrap = path.join(PROJ, 'npm-shrinkwrap.json');
+        fs.readFile(shrinkwrap, 'utf8', function (err, file) {
+            assert.ifError(err);
+            assert.notEqual(file, '');
+
+            var json = JSON.parse(file);
+
+            assert.equal(json.name, 'proj');
+            assert.equal(json.version, '0.1.0');
+            assert.deepEqual(json.dependencies, {
+                '@th507/foo': {
+                    version: '1.0.0',
+                    resolved: 'https://registry.npmjs.org/@th507/foo/-/@th507/foo-1.0.0.tgz'
+                }
+            });
+
+            assert.end();
+        });
+    });
+}, {
+  mkdirp: mkdirp,
+  fs: _fs
+}));
+
 
 test('create shrinkwrap for git dep', fixtures(__dirname, {
     'proj': moduleFixture('proj', '0.1.0', {

--- a/test/npm-shrinkwrap.js
+++ b/test/npm-shrinkwrap.js
@@ -272,8 +272,7 @@ test('error on additional GIT module', fixtures(__dirname, {
         dependencies: {
             'foo': 'git://github.com:uber/foo#v1.0.0'
         },
-        'node_modules': {},
-        nonono: 1
+        'node_modules': {}
     })
 }, function (assert) {
     npmShrinkwrap(OPT, function (err) {


### PR DESCRIPTION
- support scoped package (Fix #78, must run w/ npm >=2.0, see `--use-global-npm`)
- support calling global instead of local/bundled npm (via `--use-global-npm`)