### PR TITLE
Handle file: protocol modules

### DIFF
--- a/analyze-dependency.js
+++ b/analyze-dependency.js
@@ -95,6 +95,10 @@ function analyzeDependency(name, gitLink, opts, cb) {
 
 function parseTag(value) {
     var uri = url.parse(value);
+    
+    if (isFileUrl(uri)) {
+      return null;
+    }
 
     if (isGitUrl(uri)) {
         return {
@@ -123,6 +127,10 @@ function isGitUrl (url) {
         case "git+ssh:":
             return true;
     }
+}
+
+function isFileUrl (url) {
+    return url.protocol === 'file:';
 }
 
 function parseVersion(tag) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "json-diff": "^0.3.1",
     "minimist": "^1.1.0",
     "msee": "^0.1.1",
-    "npm": "1.4.21",
+    "npm": "2.12.0",
     "read-json": "0.1.0",
     "rimraf": "^2.2.8",
     "run-parallel": "^1.0.0",

--- a/sync/force-install.js
+++ b/sync/force-install.js
@@ -113,6 +113,8 @@ function isCorrect(filePath, dep, opts, cb) {
         resolvedUri.protocol === 'git+https:'
     ) {
         isCorrectSHA(filePath, dep, cb);
+    } else if (resolvedUri.protocol === 'file:') {
+        isCorrectFileProtocol(filePath, dep, cb);
     } else {
         cb(new Error('unsupported protocol ' +
             resolvedUri.protocol));
@@ -168,6 +170,14 @@ function isCorrectSHA(filePath, dep, cb) {
 
         cb(null, dep);
     });
+}
+
+function isCorrectFileProtocol(filePath, dep, cb) {
+  // Always force a reinstall of file modules, in case the version in node_modules
+  // is different from the file. This can happen as npm copies the directory into
+  // node_modules, instead of symlinking it (unless you use something like linklocal)
+  dep.correct = false;
+  cb(null, dep);
 }
 
 function getSha(uri) {


### PR DESCRIPTION
This pull request attempts to solve https://github.com/uber/npm-shrinkwrap/issues/61.

We're using `file:` protocols for "local" modules: in other words, modules that are not published to a registry, and are in the same repository as the main code base. Doing this gives us better dependency management and the ability to break the modules out into full-blown npm modules at a later stage without having to untangle dependencies, etc.

In the `package.json` we declare a dependency like:
```json
  "dependencies": {
   "local-module-xyz": "file:modules/xyz" 
  }
```

In our code, we can then reference this module like so
```javascript
var xyz = require("local-module-xyz");
```

Currently `npm-shrinkwrap` doesn't support file protocol modules but I'd really like it if it did. 

Feedback would be appreciated.

Note that I've updated the `npm` dependency to `2.12.0`. I'm not sure if you're using such an old `npm` version for any reason?