### PR TITLE
Use graceful-fs

### DIFF
--- a/analyze-dependency.js
+++ b/analyze-dependency.js
@@ -1,7 +1,7 @@
 var url = require('url');
 var validSemver = require('semver').valid;
 var path = require('path');
-var readJSON = require('read-json');
+var readJSON = require('./read-json');
 
 var errors = require('./errors.js');
 

--- a/bin/diff.js
+++ b/bin/diff.js
@@ -1,6 +1,6 @@
 var parallel = require('run-parallel');
 var path = require('path');
-var readJSON = require('read-json');
+var readJSON = require('../read-json');
 var jsonDiff = require('json-diff');
 var colorize = require('json-diff/lib/colorize');
 var exec = require('child_process').exec;

--- a/bin/help.js
+++ b/bin/help.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var fs = require('fs');
+var fs = require('graceful-fs');
 var msee = require('msee');
 var template = require('string-template');
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -1,6 +1,6 @@
 var path = require('path');
 var readJSON = require('read-json');
-var fs = require('fs');
+var fs = require('graceful-fs');
 var template = require('string-template');
 
 var version = require('../package.json').version;

--- a/bin/install.js
+++ b/bin/install.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var readJSON = require('read-json');
+var readJSON = require('../read-json');
 var fs = require('graceful-fs');
 var template = require('string-template');
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var ValidationError = require('error/validation');
 var find = require('array-find');
 var path = require('path');
-var fs = require('fs');
+var fs = require('graceful-fs');
 var sortedObject = require('sorted-object');
 var readJSON = require('read-json');
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var find = require('array-find');
 var path = require('path');
 var fs = require('graceful-fs');
 var sortedObject = require('sorted-object');
-var readJSON = require('read-json');
+var readJSON = require('./read-json');
 
 var setResolved = require('./set-resolved.js');
 var trimFrom = require('./trim-and-sort-shrinkwrap.js');

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "minimist": "^1.1.0",
     "msee": "^0.1.1",
     "npm": "1.4.21",
-    "read-json": "0.1.0",
     "rimraf": "^2.2.8",
     "run-parallel": "^1.0.0",
     "run-series": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "array-find": "^0.1.1",
     "error": "^4.2.0",
+    "graceful-fs": "^4.1.2",
     "json-diff": "^0.3.1",
     "minimist": "^1.1.0",
     "msee": "^0.1.1",

--- a/read-json.js
+++ b/read-json.js
@@ -1,0 +1,27 @@
+// From https://github.com/azer/read-json
+// Licensed under the BSD license
+// Adapted to use graceful-fs
+
+var fs = require("graceful-fs");
+
+module.exports = readJSON;
+
+function readJSON(filename, options, callback){
+  if(callback === undefined){
+    callback = options;
+    options = {};
+  }
+
+  fs.readFile(filename, options, function(error, bf){
+    if(error) return callback(error);
+
+    try {
+      bf = JSON.parse(bf.toString().replace(/^\ufeff/g, ''));
+    } catch (err) {
+      callback(err);
+      return;
+    }
+
+    callback(undefined, bf);
+  });
+}

--- a/set-resolved.js
+++ b/set-resolved.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var fs = require('fs');
+var fs = require('graceful-fs');
 var template = require('string-template');
 var readJSON = require('read-json');
 var url = require('url');

--- a/set-resolved.js
+++ b/set-resolved.js
@@ -1,7 +1,7 @@
 var path = require('path');
 var fs = require('graceful-fs');
 var template = require('string-template');
-var readJSON = require('read-json');
+var readJSON = require('./read-json');
 var url = require('url');
 var semver = require('semver');
 

--- a/sync/index.js
+++ b/sync/index.js
@@ -1,9 +1,6 @@
 var path = require('path');
-// var fs = require('graceful-fs');
-// var readJSON = require('read-json');
 var parallel = require('run-parallel');
 var npm = require('npm');
-// var rimraf = require('rimraf');
 
 var read = require('./read.js');
 var forceInstall = require('./force-install.js');

--- a/sync/index.js
+++ b/sync/index.js
@@ -1,5 +1,5 @@
 var path = require('path');
-// var fs = require('fs');
+// var fs = require('graceful-fs');
 // var readJSON = require('read-json');
 var parallel = require('run-parallel');
 var npm = require('npm');

--- a/sync/purge-excess.js
+++ b/sync/purge-excess.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var fs = require('fs');
+var fs = require('graceful-fs');
 var parallel = require('run-parallel');
 var rimraf = require('rimraf');
 

--- a/sync/read.js
+++ b/sync/read.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var readJSON = require('read-json');
+var readJSON = require('../read-json');
 var TypedError = require('error/typed');
 
 var FileNotFound = TypedError({

--- a/test/git-https-use-case.js
+++ b/test/git-https-use-case.js
@@ -1,6 +1,6 @@
 var test = require('tape');
 var path = require('path');
-var fs = require('fs');
+var fs = require('graceful-fs');
 var safeJsonParse = require('safe-json-parse');
 var fixtures = require('fixtures-fs');
 var exec = require('child_process').exec;

--- a/test/npm-shrinkwrap.js
+++ b/test/npm-shrinkwrap.js
@@ -1,7 +1,7 @@
 var test = require('tape');
 var fixtures = require('fixtures-fs');
 var path = require('path');
-var fs = require('fs');
+var fs = require('graceful-fs');
 
 var npmShrinkwrap = require('../index.js');
 

--- a/trim-and-sort-shrinkwrap.js
+++ b/trim-and-sort-shrinkwrap.js
@@ -4,7 +4,7 @@ var url = require('url');
 var safeJsonParse = require('safe-json-parse');
 var parallel = require('run-parallel');
 var sortedObject = require('sorted-object');
-var readJSON = require('read-json');
+var readJSON = require('./read-json');
 
 var errors = require('./errors.js');
 

--- a/trim-and-sort-shrinkwrap.js
+++ b/trim-and-sort-shrinkwrap.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('graceful-fs');
 var path = require('path');
 var url = require('url');
 var safeJsonParse = require('safe-json-parse');

--- a/verify-git.js
+++ b/verify-git.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var readJSON = require('read-json');
+var readJSON = require('./read-json');
 var parallel = require('run-parallel');
 
 var analyzeDependency = require('./analyze-dependency.js');


### PR DESCRIPTION
Addresses EMFILE errors, as mentioned in #85.

Unfortunately `read-json` is used extensively and also triggers EMFILE with a large number of dependencies, and so I had to add a local version of the `read-json.js` file which uses `graceful-fs` instead of `fs`.