### PR TITLE
Diff fails when shrinkwrap file not at repository root

### DIFF
--- a/bin/diff.js
+++ b/bin/diff.js
@@ -86,7 +86,7 @@ function gitShow(sha, cwd, callback) {
         jsonParse(stdout, callback);
     }
 
-    exec('git show ' + sha + ':npm-shrinkwrap.json', {
+    exec('git show ' + sha + ':./npm-shrinkwrap.json', {
         cwd: cwd || process.cwd(),
         maxBuffer: 10000 * 1024
     }, ongit);


### PR DESCRIPTION
The `git show` command always looks at the root of the repository when showing a file, so the command was not being executed properly.

Because the `cwd` of the `exec()` call is explicitly the current working directory or the `--dirname` value, using the `./npm-shrinkwrap.json` file after show will always show the desired directories shrinkwrap file.