### PR TITLE
Fix git uris to normalize from ":" to "/"

### DIFF
--- a/set-resolved.js
+++ b/set-resolved.js
@@ -84,6 +84,25 @@ function setResolved(opts, callback) {
             json.resolved = rewriteResolved(json.resolved);
         }
 
+        var u;
+
+        // Handle the annoying / vs : on resolved & from
+        if (json.resolved && json.resolved.indexOf('git+ssh://') > -1) {
+            u = url.parse(json.resolved);
+            if (u.pathname.indexOf('/:') === 0) {
+                u.pathname = u.pathname[0] + u.pathname.slice(2, u.pathname.length);
+                json.resolved = url.format(u);
+            }
+        }
+
+        if (json.from && json.from.indexOf('git+ssh://') > -1) {
+            u = url.parse(json.from);
+            if (u.pathname.indexOf('/:') === 0) {
+                u.pathname = u.pathname[0] + u.pathname.slice(2, u.pathname.length);
+                json.from = url.format(u);
+            }
+        }
+
         if (json.dependencies) {
             Object.keys(json.dependencies).forEach(function (dep) {
                 fixResolved(json.dependencies[dep], dep);

--- a/test/npm-shrinkwrap.js
+++ b/test/npm-shrinkwrap.js
@@ -202,7 +202,7 @@ test('error on removed GIT module', fixtures(__dirname, {
 test('error on additional GIT module', fixtures(__dirname, {
     proj: moduleFixture('proj', '0.1.0', {
         dependencies: {
-            'foo': 'git://github.com:uber/foo#v1.0.0'
+            'foo': 'git://github.com/uber/foo#v1.0.0'
         },
         'node_modules': {}
     })
@@ -211,7 +211,7 @@ test('error on additional GIT module', fixtures(__dirname, {
         assert.ok(err);
 
         assert.notEqual(err.message.indexOf(
-            'missing: foo@git://github.com:uber/foo#v1.0.0'), -1);
+            'missing: foo@git://github.com/uber/foo.git#v1.0.0'), -1);
 
         assert.end();
     });


### PR DESCRIPTION
This changes npm-shrinkwrap so that it can fix these annoying
git links from not being stable.

Someone still has to pay first mover cost but after that it's
easy sailing

r: @arkajit 

cc: @weikai77