### PR TITLE
Remove external dependency read-json

### DIFF
--- a/analyze-dependency.js
+++ b/analyze-dependency.js
@@ -1,7 +1,7 @@
 var url = require('url');
 var validSemver = require('semver').valid;
 var path = require('path');
-var readJSON = require('read-json');
+var readJSON = require('./read-json');
 
 var errors = require('./errors.js');
 

--- a/bin/diff.js
+++ b/bin/diff.js
@@ -1,6 +1,6 @@
 var parallel = require('run-parallel');
 var path = require('path');
-var readJSON = require('read-json');
+var readJSON = require('../read-json');
 var jsonDiff = require('json-diff');
 var colorize = require('json-diff/lib/colorize');
 var exec = require('child_process').exec;

--- a/bin/install.js
+++ b/bin/install.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var readJSON = require('read-json');
+var readJSON = require('../read-json');
 var fs = require('fs');
 var template = require('string-template');
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var find = require('array-find');
 var path = require('path');
 var fs = require('fs');
 var sortedObject = require('sorted-object');
-var readJSON = require('read-json');
+var readJSON = require('./read-json');
 
 var setResolved = require('./set-resolved.js');
 var trimFrom = require('./trim-and-sort-shrinkwrap.js');
@@ -18,7 +18,7 @@ var ERRORS = require('./errors.js');
      - run `npm ls` to verify that node_modules & package.json
         agree.
 
-     - run `verifyGit()` which has a similar algorithm to 
+     - run `verifyGit()` which has a similar algorithm to
         `npm ls` and will verify that node_modules & package.json
         agree for all git links.
 
@@ -288,11 +288,11 @@ function npmShrinkwrap(opts, callback) {
         callback(null, warnings);
     }
 }
- 
+
 module.exports = npmShrinkwrap;
 
 /*  you cannot call `npm.load()` twice with different prefixes.
-    
+
     The only fix is to clear the entire node require cache and
       get a fresh duplicate copy of the entire npm library
 */

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
   "dependencies": {
     "array-find": "^0.1.1",
     "error": "^4.2.0",
+    "graceful-fs": "^4.1.2",
     "json-diff": "^0.3.1",
     "minimist": "^1.1.0",
     "msee": "^0.1.1",
     "npm": "^2.1.10",
-    "read-json": "0.1.0",
     "rimraf": "^2.2.8",
     "run-parallel": "^1.0.0",
     "run-series": "^1.0.2",

--- a/read-json.js
+++ b/read-json.js
@@ -1,0 +1,27 @@
+// From https://github.com/azer/read-json
+// Licensed under the BSD license
+// Adapted to use graceful-fs
+
+var fs = require("graceful-fs");
+
+module.exports = readJSON;
+
+function readJSON(filename, options, callback){
+  if(callback === undefined){
+    callback = options;
+    options = {};
+  }
+
+  fs.readFile(filename, options, function(error, bf){
+    if(error) return callback(error);
+
+    try {
+      bf = JSON.parse(bf.toString().replace(/^\ufeff/g, ''));
+    } catch (err) {
+      callback(err);
+      return;
+    }
+
+    callback(undefined, bf);
+  });
+}

--- a/set-resolved.js
+++ b/set-resolved.js
@@ -1,7 +1,7 @@
 var path = require('path');
 var fs = require('fs');
 var template = require('string-template');
-var readJSON = require('read-json');
+var readJSON = require('./read-json');
 var url = require('url');
 var semver = require('semver');
 

--- a/sync/index.js
+++ b/sync/index.js
@@ -1,6 +1,5 @@
 var path = require('path');
 // var fs = require('fs');
-// var readJSON = require('read-json');
 var parallel = require('run-parallel');
 var npm = require('npm');
 // var rimraf = require('rimraf');

--- a/sync/read.js
+++ b/sync/read.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var readJSON = require('read-json');
+var readJSON = require('../read-json');
 var TypedError = require('error/typed');
 
 var FileNotFound = TypedError({

--- a/trim-and-sort-shrinkwrap.js
+++ b/trim-and-sort-shrinkwrap.js
@@ -4,7 +4,7 @@ var url = require('url');
 var safeJsonParse = require('safe-json-parse');
 var parallel = require('run-parallel');
 var sortedObject = require('sorted-object');
-var readJSON = require('read-json');
+var readJSON = require('./read-json');
 
 var errors = require('./errors.js');
 

--- a/verify-git.js
+++ b/verify-git.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var readJSON = require('read-json');
+var readJSON = require('./read-json');
 var parallel = require('run-parallel');
 
 var analyzeDependency = require('./analyze-dependency.js');


### PR DESCRIPTION
This is a PR for **npm2.0** branch.

Background: https://medium.com/@azerbike/i-ve-just-liberated-my-modules-9045c06be67c#.72w3ys4e1 and the reactions following that, which I am sure we have not seen the last of, it would be nice to have stable builds again.

Instead of using Azer's `read-json`, we can use the `read-json` implementation that's already in `master`