### PR TITLE
Use parallel-limit instead of parallel

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -37,6 +37,8 @@ function main(opts, callback) {
 
     opts.cmd = opts.cmd || 'npm-shrinkwrap';
 
+    opts.limit = opts.limit || 0;
+
     if (command === 'install') {
         return installModule(opts, function (err) {
             if (err) {

--- a/bin/diff.js
+++ b/bin/diff.js
@@ -1,4 +1,4 @@
-var parallel = require('run-parallel');
+var parallelLimit = require('run-parallel-limit');
 var path = require('path');
 var readJSON = require('read-json');
 var jsonDiff = require('json-diff');
@@ -123,14 +123,14 @@ function main(opts, callback) {
     opts.depth = 'depth' in opts ? opts.depth : 0;
     var cwd = opts.dirname || process.cwd();
 
-    parallel([
+    parallelLimit([
         isFile(fileA) ?
             readJSON.bind(null, path.resolved(cwd, fileA)) :
             gitShow.bind(null, fileA, cwd),
         isFile(fileB) ?
             readJSON.bind(null, path.resolve(cwd, fileB)) :
             gitShow.bind(null, fileB, cwd)
-    ], function (err, files) {
+    ], opts.limit, function (err, files) {
         if (err) {
             return callback(err);
         }

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ var ERRORS = require('./errors.js');
      - run `npm ls` to verify that node_modules & package.json
         agree.
 
-     - run `verifyGit()` which has a similar algorithm to 
+     - run `verifyGit()` which has a similar algorithm to
         `npm ls` and will verify that node_modules & package.json
         agree for all git links.
 
@@ -65,6 +65,7 @@ function npmShrinkwrap(opts, callback) {
     if (typeof opts === 'string') {
         opts = { dirname: opts };
     }
+    opts.limit = opts.limit || 0;
 
     var _warnings = null;
     var _oldShrinkwrap = null;
@@ -288,11 +289,11 @@ function npmShrinkwrap(opts, callback) {
         callback(null, warnings);
     }
 }
- 
+
 module.exports = npmShrinkwrap;
 
 /*  you cannot call `npm.load()` twice with different prefixes.
-    
+
     The only fix is to clear the entire node require cache and
       get a fresh duplicate copy of the entire npm library
 */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-shrinkwrap",
-  "version": "200.4.0",
+  "version": "200.5.0",
   "description": "A consistent shrinkwrap tool",
   "keywords": [],
   "author": "Raynos <raynos2@gmail.com>",
@@ -20,7 +20,7 @@
     "npm": "^2.1.10",
     "read-json": "0.1.0",
     "rimraf": "^2.2.8",
-    "run-parallel": "^1.0.0",
+    "run-parallel-limit": "^1.0.3",
     "run-series": "^1.0.2",
     "safe-json-parse": "^2.0.0",
     "semver": "^4.0.3",

--- a/sync/force-install.js
+++ b/sync/force-install.js
@@ -1,6 +1,6 @@
 var path = require('path');
 var url = require('url');
-var parallel = require('run-parallel');
+var parallelLimit = require('run-parallel-limit');
 var series = require('run-series');
 var template = require('string-template');
 
@@ -38,7 +38,7 @@ function forceInstall(nodeModules, shrinkwrap, opts, cb) {
     tasks.push(purgeExcess.bind(
         null, nodeModules, shrinkwrap, opts));
 
-    parallel(tasks, function (err, results) {
+    parallelLimit(tasks, opts.limit, function (err, results) {
         if (err) {
             return cb(err);
         }
@@ -90,7 +90,7 @@ function forceInstall(nodeModules, shrinkwrap, opts, cb) {
 
         var tasks = [].concat(inCorrectTasks, correctTasks);
 
-        parallel(tasks, cb);
+        parallelLimit(tasks, opts.limit, cb);
     });
 }
 

--- a/sync/index.js
+++ b/sync/index.js
@@ -1,7 +1,7 @@
 var path = require('path');
 // var fs = require('fs');
 // var readJSON = require('read-json');
-var parallel = require('run-parallel');
+var parallelLimit = require('run-parallel-limit');
 var npm = require('npm');
 // var rimraf = require('rimraf');
 
@@ -37,10 +37,10 @@ function syncShrinkwrap(opts, cb) {
 
         opts.npm = npm;
 
-        parallel({
+        parallelLimit({
             shrinkwrap: read.shrinkwrap.bind(null, dirname),
             devDependencies: read.devDependencies.bind(null, dirname)
-        }, function (err, tuple) {
+        }, opts.limit, function (err, tuple) {
             if (err) {
                 return cb(err);
             }

--- a/sync/purge-excess.js
+++ b/sync/purge-excess.js
@@ -1,6 +1,6 @@
 var path = require('path');
 var fs = require('fs');
-var parallel = require('run-parallel');
+var parallelLimit = require('run-parallel-limit');
 var rimraf = require('rimraf');
 
 module.exports = purgeExcess;
@@ -31,7 +31,7 @@ function purgeExcess(dir, shrinkwrap, opts, cb) {
             return rimraf.bind(null, filePath);
         });
 
-        parallel(tasks, cb);
+        parallelLimit(tasks, opts.limit, cb);
     });
 }
 

--- a/trim-and-sort-shrinkwrap.js
+++ b/trim-and-sort-shrinkwrap.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var url = require('url');
 var safeJsonParse = require('safe-json-parse');
-var parallel = require('run-parallel');
+var parallelLimit = require('run-parallel-limit');
 var sortedObject = require('sorted-object');
 var readJSON = require('read-json');
 
@@ -69,10 +69,10 @@ function trimFrom(opts, callback) {
     var shrinkwrapFile = path.join(opts.dirname, 'npm-shrinkwrap.json');
     var registries = opts.registries || ['registry.npmjs.org'];
 
-    parallel([
+    parallelLimit([
         fixShrinkwrap,
         fixPackage.bind(null, opts.dirname)
-    ], callback);
+    ], opts.limit, callback);
 
 
     function fixShrinkwrap(callback) {

--- a/verify-git.js
+++ b/verify-git.js
@@ -1,6 +1,6 @@
 var path = require('path');
 var readJSON = require('read-json');
-var parallel = require('run-parallel');
+var parallelLimit = require('run-parallel-limit');
 
 var analyzeDependency = require('./analyze-dependency.js');
 
@@ -23,10 +23,10 @@ function verifyGit(opts, callback) {
         var deps = package.dependencies || {};
         var devDeps = package.devDependencies || {};
 
-        parallel([
+        parallelLimit([
             analyze.bind(null, deps, opts),
             opts.dev ? analyze.bind(null, devDeps, opts) : null
-        ].filter(Boolean), function (err, values) {
+        ].filter(Boolean), opts.limit, function (err, values) {
             if (err) {
                 return callback(err);
             }
@@ -44,7 +44,7 @@ function analyze(deps, opts, callback) {
             key, deps[key], opts);
     });
 
-    parallel(tasks, function (err, results){
+    parallelLimit(tasks, opts.limit, function (err, results){
         if (err) {
             return callback(err);
         }


### PR DESCRIPTION
Default limit is 0 which has the same behavior as regular `parallel`. Now supports passing in a `limit` option which will be used with `run-parallel-limit`.

This addresses issues when running `sync` against a large shrinkwrap.