### PR TITLE
Fix the type error "path.resolved is not a function" when the first parameter is a file

### DIFF
--- a/bin/diff.js
+++ b/bin/diff.js
@@ -125,7 +125,7 @@ function main(opts, callback) {
 
     parallel([
         isFile(fileA) ?
-            readJSON.bind(null, path.resolved(cwd, fileA)) :
+            readJSON.bind(null, path.resolve(cwd, fileA)) :
             gitShow.bind(null, fileA, cwd),
         isFile(fileB) ?
             readJSON.bind(null, path.resolve(cwd, fileB)) :


### PR DESCRIPTION
Currently when use diff with a file name as the first parameter, a Type Error is thrown:

```
$ npm-shrinkwrap diff npm-shrinkwrap.json npm-shrinkwrap.json
TypeError: path.resolved is not a function
    at main (*****\npm-shrinkwrap\bin\diff.js:128:38)
```

This is caused a typo. After this fix it works fine.