### PR TITLE
Fix error when `shrinkwrap.dependencies` is undefined

### DIFF
--- a/sync/purge-excess.js
+++ b/sync/purge-excess.js
@@ -86,7 +86,7 @@ function validateExcess(dir, file, shrinkwrap, opts, scope, cb) {  // jshint ign
 
     // the file is in excess if it does not exist in the package.json's
     // regular dependencies
-    if (lowercaseContains(Object.keys(shrinkwrap.dependencies), file)) {
+    if (shrinkwrap.dependencies && lowercaseContains(Object.keys(shrinkwrap.dependencies), file)) {
         return cb();
     }
 


### PR DESCRIPTION
I have no idea why this is happening, but I currently get:
```sh
 if (lowercaseContains(Object.keys(shrinkwrap.dependencies), file)) {
                                 ^

TypeError: Cannot convert undefined or null to object
    at Function.keys (native)
    at validateExcess (/tmp/d20160825-18026-1edas05/monorail-solano-ghe/node_modules/npm-shrinkwrap/sync/purge-excess.js:89:34)
```

and this seems like it would fix it.